### PR TITLE
Fix pod oom events cannot be emitted

### DIFF
--- a/deployment/node-problem-detector-config.yaml
+++ b/deployment/node-problem-detector-config.yaml
@@ -27,6 +27,11 @@ data:
             },
             {
                 "type": "temporary",
+                "reason": "PodOOMKilling",
+                "pattern": "Task in /kubepods/\\S+ killed as a result of limit of /kubepods/\\S+"
+            },
+            {
+                "type": "temporary",
                 "reason": "TaskHung",
                 "pattern": "task \\S+:\\w+ blocked for more than \\w+ seconds\\."
             },

--- a/pkg/systemlogmonitor/log_monitor.go
+++ b/pkg/systemlogmonitor/log_monitor.go
@@ -18,6 +18,7 @@ package systemlogmonitor
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/heapster/common/kubernetes"
@@ -26,9 +27,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
-
-	"fmt"
 	"time"
 
 	"github.com/golang/glog"
@@ -65,7 +63,7 @@ func init() {
 }
 
 func init() {
-	uuidRegx = regexp.MustCompile("[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}")
+	uuidRegx = regexp.MustCompile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
 }
 
 type logMonitor struct {
@@ -205,7 +203,6 @@ func (l *logMonitor) generateStatus(logs []*logtypes.Log, rule systemlogtypes.Ru
 	if rule.Reason == OOMREASON && k8sClient != nil {
 		uuid := string(uuidRegx.Find([]byte(message)))
 
-		uuid = strings.ReplaceAll(uuid, "_", "-")
 		pl, err := k8sClient.CoreV1().Pods("").List(metav1.ListOptions{})
 		if err != nil {
 			glog.Error("Error in getting pods: %v", err.Error())


### PR DESCRIPTION
Fix pod oom events cannot be emitted due to regular expression error and lack of kernel-monitor rule whose reason is PodOOMKilling.

https://github.com/AliyunContainerService/node-problem-detector/blob/71bd5f88c07b2671fa8e898f16e58b49d241ed73/pkg/systemlogmonitor/log_monitor.go#L190-L194

https://github.com/AliyunContainerService/node-problem-detector/blob/71bd5f88c07b2671fa8e898f16e58b49d241ed73/pkg/systemlogmonitor/log_monitor.go#L204-L206

Because this is based on whether the reason is `PodOOMKilling`, so there has to be such a rule that can both be matched by the `uuidRegx` regular expression in the code. 

